### PR TITLE
Fix HTML start tag formatting

### DIFF
--- a/Bionic.py
+++ b/Bionic.py
@@ -154,7 +154,10 @@ def process_html_file(html_file, first_tags):
         if len(html_part) == 2 and html_part[0][0] == 'Start tag:':
             tag = '<' + html_part[0][1]
             full_attr = [f'{attr[0]}="{attr[1]}"' for attr in html_part[1][1]]
-            tag += ' ' + ' '.join(full_attr) + '>'
+            attr_str = ' '.join(full_attr)
+            if attr_str:
+                tag += ' ' + attr_str
+            tag += '>'
             full_html += tag
         if html_part[0] == 'End tag:':
             tag = f"</{html_part[1]}>"


### PR DESCRIPTION
## Summary
- fix extraneous space when writing start tags

## Testing
- `python -m py_compile Bionic.py`


------
https://chatgpt.com/codex/tasks/task_e_68404a62c94083259de9a24b690eecac